### PR TITLE
completion/nikto: simplify and use `-X '!&*'`

### DIFF
--- a/completion/available/nikto.completion.bash
+++ b/completion/available/nikto.completion.bash
@@ -1,43 +1,35 @@
 # shellcheck shell=bash
 
 __nikto_completion() {
-	local prev=$(_get_pword)
-	local curr=$(_get_cword)
+	local cur=${COMP_WORDS[COMP_CWORD]}
+	local prev=${COMP_WORDS[COMP_CWORD - 1]:-}
 
 	case $prev in
 		-ask)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "yes no auto" -- "$curr"))
+			COMPREPLY=("yes" "no" "auto")
 			;;
 		-Display)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "1 2 3 4 D E P S V" -- "$curr"))
+			COMPREPLY=('1' '2' '3' '4' 'D' 'E' 'P' 'S' 'V')
 			;;
 		-evasion)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "1 2 3 4 5 6 7 8 A B" -- "$curr"))
+			COMPREPLY=('1' '2' '3' '4' '5' '6' '7' '8' 'A' 'B')
 			;;
 		-Format)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "csv htm nbe sql txt xml" -- "$curr"))
+			COMPREPLY=('csv' 'htm' 'nbe' 'sql' 'txt' 'xml')
 			;;
 		-mutate)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "1 2 3 4 5 6" -- "$curr"))
+			COMPREPLY=('1' '2' '3' '4' '5' '6')
 			;;
 		-Tuning)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "0 1 2 3 4 5 6 7 8 9 a b c d e x" -- "$curr"))
+			COMPREPLY=('0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'a' 'b' 'c' 'd' 'e' 'x')
 			;;
 		-Userdbs)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "all none" -- "$curr"))
+			COMPREPLY=('all' 'none')
 			;;
 		*)
-			# shellcheck disable=SC2207
-			COMPREPLY=($(compgen -W "-H -Help -ask -Cgidirs -config -Display -dbcheck -evasion -Format -host -404code -404string -id -key -list-plugins -maxtime -mutate -mutate-options -nointeractive -nolookup -nossl -no404 -Option -output -Pause -Plugins -port -RSAcert -root -Save -ssl -Tuning -timeout -Userdbs -useragent -until -update -useproxy -Verbost -vhost" -- "$curr"))
+			COMPREPLY=('-H' '-Help' '-ask' '-Cgidirs' '-config' '-Display' '-dbcheck' '-evasion' '-Format' '-host' '-404code' '-404string' '-id' '-key' '-list-plugins' '-maxtime' '-mutate' '-mutate-options' '-nointeractive' '-nolookup' '-nossl' '-no404' '-Option' '-output' '-Pause' '-Plugins' '-port' '-RSAcert' '-root' '-Save' '-ssl' '-Tuning' '-timeout' '-Userdbs' '-useragent' '-until' '-update' '-useproxy' '-Verbost' '-vhost')
 			;;
 	esac
 }
 
-complete -F __nikto_completion nikto
+complete -F __nikto_completion -X '!&*' nikto


### PR DESCRIPTION
## Description
This is meant to simplify the completion code by taking advantage of `complete -X '!&*'`. 

## Motivation and Context
This basically eliminates the need to filter the completions, which makes it super easy to avoid a pile of warnings and possible parsing errors.

@tbhaxor, if you accept this PR against *your* fork, then it will automatically update the PR against the main repo 😃 

## How Has This Been Tested?
Works for me!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [x] I have added tests to cover my changes, and all the new and existing tests pass.
